### PR TITLE
Added support for colorspace processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ To use those, you should include specified module (RMagick or MiniMagick) into y
       process :resize_to_fill => [200, 200]
       process :quality => 90 # Set JPEG/MIFF/PNG compression level (0-100)
       process :convert => 'png'
+      process :colorspace => :rgb # Set colorspace to rgb or cmyk
 
       def filename
         super.chomp(File.extname(super)) + '.png'

--- a/lib/carrierwave-processing/mini_magick.rb
+++ b/lib/carrierwave-processing/mini_magick.rb
@@ -18,6 +18,25 @@ module CarrierWave
           img
         end
       end
+
+      # Sets the colorspace of the image to the specified value.
+      # 
+      #   process :rgb # force rgb
+      #   process :cmyk # force cmyk
+      # 
+      def colorspace(cs)
+        manipulate! do |img|
+          case cs.to_sym
+          when :rgb
+            img.colorspace = "RGBColorspace"
+          when :cmyk
+            img.colorspace = "CMYKColorspace"
+          end
+          img = yield(img) if block_given?
+          img
+        end
+      end
+
     end
   end
 end

--- a/lib/carrierwave-processing/rmagick.rb
+++ b/lib/carrierwave-processing/rmagick.rb
@@ -18,6 +18,25 @@ module CarrierWave
           img
         end
       end
+
+      # Sets the colorspace of the image to the specified value.
+      # 
+      #   process :rgb # force rgb
+      #   process :cmyk # force cmyk
+      # 
+      def colorspace(cs)
+        manipulate! do |img|
+          case cs.to_sym
+          when :rgb
+            img.colorspace = Magick::RGBColorspace
+          when :cmyk
+            img.colorspace = Magick::CMYKColorspace
+          end
+          img = yield(img) if block_given?
+          img
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
I've often found myself adding colorspace processing to my uploaders, since clients and users often don't know how to save an image for web before uploading. Almost all my image versions for web end up forcing rgb, just to be safe. IE8 does not support cmyk colorspace, and I can't remember which other browsers don't. 

Options include :rgb and :cmyk.

```
process :rgb
```

or 

```
process :cmyk
```

Simple as that. Rmagick and Minimagick both supported.
